### PR TITLE
Add dh-virtualenv custom buster build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,9 @@ COPY entrypoint.sh /entrypoint.sh
 RUN apt-get update
 RUN apt-get install build-essential debhelper devscripts -y
 
+# Install `dh-virtualenv` 1.2
+RUN curl --output /tmp/dh-virtualenv.deb https://download.nylas.com/gha-deps/dh-virtualenv_1.2.2-1~buster_all.deb
+RUN apt-get install --yes /tmp/dh-virtualenv.deb
+
 # Code file to execute when the docker container starts up (`entrypoint.sh`)
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
debian stable repo only has dh-virtualenv v1.0
need to do a custom build of version >= 1.2

Source code https://github.com/spotify/dh-virtualenv
dh-virtualenv version: 1.2.2
OS version: debian:stable